### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,10 @@ author: Raouf Rahiche <rraouf30@gmail.com>
 homepage: https://github.com/Rahiche/Flutter-Badge
 
 environment:
-  sdk: '>=1.20.1 <=2.2.0'
-
+ # sdk: '>=1.20.1 <=2.2.0'
+  sdk: ">=1.20.1 <3.0.0"
+  flutter: ">=0.1.4 <2.0.0"
+  
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
The current Dart SDK version is 2.1.2-dev.0.0.flutter-0a7dcf17eb.

Because WiaDog depends on badge >=0.0.2 which requires SDK version >=1.20.1 <=2.1.0, version solving failed.